### PR TITLE
Timing

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -261,7 +261,6 @@ namespace {
     
     client->current_phase = MAIN_DURATION;
     
-    ev_timer_stop(client->worker->loop, &client->warmup_watcher);
     std::cout << "Warm-up phase is over for client: " << client->id << std::endl;
     
     client->worker->stats.req_started -= client->req_started;
@@ -300,7 +299,6 @@ namespace {
     }
     
     if (client->worker->current_phase != DURATION_OVER) {
-      ev_timer_stop(client->worker->loop, &client->duration_watcher);
     
       client->worker->current_phase = DURATION_OVER;
       client->worker->stop_all_clients();

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -273,7 +273,11 @@ void duration_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   }
 
   worker->current_phase = Phase::DURATION_OVER;
+
+  std::cout << "Main benchmark duration is over for thread #" 
+            << worker->id << ". Stopping all clients." << std::endl;
   worker->stop_all_clients();
+  std::cout << "Stopped all clients for thread #" << worker->id << std::endl;
 }
 } // namespace
 
@@ -1318,7 +1322,9 @@ Worker::~Worker() {
 
 void Worker::stop_all_clients() {
   for(auto client: clients) {
-    client->terminate_session();
+    if(client->session) {
+      client->terminate_session();
+    }
   }
 }
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -282,8 +282,10 @@ namespace {
 void warmup_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto worker = static_cast<Worker *>(w->data);
   
-  std::cout << "Warm-up phase is over. " << std::endl;
-  std::cout << "Main benchmark duration is started." << std::endl;
+  std::cout << "Warm-up phase is over for thread #" 
+            << worker->id << "." << std::endl;
+  std::cout << "Main benchmark duration is started for thread #" 
+            << worker->id << "." << std::endl;
   
   assert (worker->stats.req_started == 0);
   assert (worker->stats.req_done == 0);
@@ -477,7 +479,8 @@ int Client::connect() {
     record_connect_start_time();
   } else if (worker->current_phase == Phase::INITIAL_IDLE) {
     worker->current_phase = Phase::WARM_UP;
-    std::cout << "Warm-up started: " << id << std::endl;
+    std::cout << "Warm-up started for thread #" << worker->id 
+              << "." << std::endl;
     ev_timer_start(worker->loop, &worker->warmup_watcher);
   }
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -274,12 +274,12 @@ void duration_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
 
   worker->current_phase = Phase::DURATION_OVER;
 
-  std::cout << "Main benchmark duration is over for thread #" 
-            << worker->id << ". Stopping all clients." << std::endl;
+  std::cout << "Main benchmark duration is over for thread #" << worker->id
+            << ". Stopping all clients." << std::endl;
   worker->stop_all_clients();
   std::cout << "Stopped all clients for thread #" << worker->id << std::endl;
 }
-} // namespace
+}  // namespace
 
 namespace {
 // Called when the warmup duration for infinite number of requests are over
@@ -294,7 +294,7 @@ void warmup_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   assert (worker->stats.req_started == 0);
   assert (worker->stats.req_done == 0);
 
-  for(auto client: worker->clients) {
+  for (auto client: worker->clients) {
     assert (client->req_todo == 0);
     assert (client->req_left == 1);
     assert (client->req_inflight == 0);
@@ -618,7 +618,7 @@ int Client::submit_request() {
   ++req_started;
   ++req_inflight;
 
-  if(!worker->config->is_timing_based_mode()) {
+  if (!worker->config->is_timing_based_mode()) {
     --req_left;
   }
   
@@ -1321,8 +1321,8 @@ Worker::~Worker() {
 }
 
 void Worker::stop_all_clients() {
-  for(auto client: clients) {
-    if(client->session) {
+  for (auto client : clients) {
+    if (client->session) {
       client->terminate_session();
     }
   }

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -290,16 +290,15 @@ void warmup_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
             << worker->id << "." << std::endl;
   std::cout << "Main benchmark duration is started for thread #" 
             << worker->id << "." << std::endl;
-  
-  assert (worker->stats.req_started == 0);
-  assert (worker->stats.req_done == 0);
+  assert(worker->stats.req_started == 0);
+  assert(worker->stats.req_done == 0);
 
-  for (auto client: worker->clients) {
-    assert (client->req_todo == 0);
-    assert (client->req_left == 1);
-    assert (client->req_inflight == 0);
-    assert (client->req_started == 0);
-    assert (client->req_done == 0);
+  for (auto client : worker->clients) {
+    assert(client->req_todo == 0);
+    assert(client->req_left == 1);
+    assert(client->req_inflight == 0);
+    assert(client->req_started == 0);
+    assert(client->req_done == 0);
     
     client->record_client_start_time();
     client->clear_connect_times();
@@ -617,11 +616,9 @@ int Client::submit_request() {
   ++worker->stats.req_started;
   ++req_started;
   ++req_inflight;
-
   if (!worker->config->is_timing_based_mode()) {
     --req_left;
   }
-  
   // if an active timeout is set and this is the last request to be submitted
   // on this connection, start the active timeout.
   if (worker->config->conn_active_timeout > 0. && req_left == 0) {

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2271,7 +2271,7 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  if (config.nreqs == 0 && !config.is_rate_mode()) {
+  if (config.nreqs == 0 && (!config.is_rate_mode() && config.warm_up_time == 0)) {
     std::cerr << "-n: the number of requests must be strictly greater than 0."
               << std::endl;
     exit(EXIT_FAILURE);
@@ -2321,6 +2321,15 @@ int main(int argc, char **argv) {
                    "to the number of clients."
                 << std::endl;
       exit(EXIT_FAILURE);
+    }
+
+    if (config.warm_up_time > 0) {
+      if (config.nclients != config.rate) {
+        std::cerr << "-r, -c: timing-related needs the connection rate to be e"
+                  << "qual to the number of clients."
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
   }
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -265,12 +265,12 @@ namespace {
     
     client->worker->stats.req_started -= client->req_started;
     client->worker->stats.req_done -= client->req_done;
-    // we also need to adjust the failed and errored
-    client->req_todo = 0;
-    client->req_left = 1;
-    client->req_inflight = 0;
-    client->req_started = 0;
-    client->req_done = 0;
+
+    assert (client->req_todo == 0);
+    assert (client->req_left == 1);
+    assert (client->req_inflight == 0);
+    assert (client->req_started == 0);
+    assert (client->req_done == 0);
     
     client->record_client_start_time();
     client->clear_connect_times();

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1708,8 +1708,7 @@ std::unique_ptr<Worker> create_worker(uint32_t id, SSL_CTX *ssl_ctx,
               << config.warm_up_time << "s of warm-up time and " 
               << config.duration << "s of main duration for measurements."
               << std::endl;
-  }
-  else {
+  } else {
     std::cout << "spawning thread #" << id << ": " << nclients
               << " total client(s). " << rate_report.str() << nreqs
               << " total requests" << std::endl;

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -228,8 +228,7 @@ void rate_period_timeout_w_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto nclients = std::min(nclients_per_second, conns_remaining);
   if (worker->config->warm_up_time > 0) {
     worker->current_phase = Phase::INITIAL_IDLE;
-  }
-  else {
+  } else {
     worker->current_phase = Phase::MAIN_DURATION;
   }
 
@@ -2697,8 +2696,7 @@ int main(int argc, char **argv) {
       // we only want to consider the rate-period if warm-up is given
       rps = stats.req_success / config.rate_period;
       bps = stats.bytes_total / config.rate_period;
-    }
-    else {
+    } else {
       auto secd = std::chrono::duration_cast<
           std::chrono::duration<double, std::chrono::seconds::period>>(duration);
       rps = stats.req_success / secd.count();

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -285,11 +285,11 @@ namespace {
 // Called when the warmup duration for infinite number of requests are over
 void warmup_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto worker = static_cast<Worker *>(w->data);
-  
-  std::cout << "Warm-up phase is over for thread #" 
-            << worker->id << "." << std::endl;
-  std::cout << "Main benchmark duration is started for thread #" 
-            << worker->id << "." << std::endl;
+
+  std::cout << "Warm-up phase is over for thread #" << worker->id << "."
+            << std::endl;
+  std::cout << "Main benchmark duration is started for thread #" << worker->id
+            << "." << std::endl;
   assert(worker->stats.req_started == 0);
   assert(worker->stats.req_done == 0);
 
@@ -299,7 +299,7 @@ void warmup_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents) {
     assert(client->req_inflight == 0);
     assert(client->req_started == 0);
     assert(client->req_done == 0);
-    
+
     client->record_client_start_time();
     client->clear_connect_times();
     client->record_connect_start_time();

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -326,11 +326,10 @@ struct Client {
   ev_timer warmup_watcher;
   std::string selected_proto;
   bool new_connection_requested;
+  bool measurement_calculation_done;
   // true if the current connection will be closed, and no more new
   // request cannot be processed.
   bool final;
-  // Keeps track of the current phase (for timing-based experiment) for the client
-  Phase current_phase;
 
   enum { ERR_CONNECT_FAIL = -100 };
 

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -85,7 +85,9 @@ struct Config {
   // rate at which connections should be made
   size_t rate;
   ev_tstamp rate_period;
-  // amount of time to wait before starting measurements
+  // amount of time for main measurements in timing-based test
+  ev_tstamp duration;
+  // amount of time to wait before starting measurements in timing-based test
   ev_tstamp warm_up_time;
   // amount of time to wait for activity on a given connection
   ev_tstamp conn_active_timeout;
@@ -120,6 +122,7 @@ struct Config {
   ~Config();
 
   bool is_rate_mode() const;
+  bool is_timing_based_mode() const;
   bool has_base_uri() const;
 };
 

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -255,6 +255,15 @@ struct Worker {
   ev_timer timeout_watcher;
   // The next client ID this worker assigns
   uint32_t next_client_id;
+  // This variable tells us whether the client is in warmup phase or not or is over
+  // 0 - Not in warm-up phase, this is the initial state in timing experiment
+  // 1 - In warmup phase. This happens after the first connect. 
+  //   - All statistics are skipped/reversed in this phase
+  // 2 - Main duration phase, in timing experiment; Otherwise, the normal phase
+  // 3 - Main duration is over
+  int warmup;
+  // We need to keep track of the clients
+  std::vector<Client*> clients;
 
   Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t nreq_todo, size_t nclients,
          size_t rate, size_t max_samples, Config *config);
@@ -265,6 +274,7 @@ struct Worker {
   void sample_client_stat(ClientStat *cstat);
   void report_progress();
   void report_rate_progress();
+  void stop_all_clients();
 };
 
 struct Stream {

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -271,6 +271,9 @@ struct Worker {
   Phase current_phase;
   // We need to keep track of the clients in order to stop them when needed
   std::vector<Client*> clients;
+  // This is only active when there is not a bounded number of requests specified
+  ev_timer duration_watcher;
+  ev_timer warmup_watcher;
 
   Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t nreq_todo, size_t nclients,
          size_t rate, size_t max_samples, Config *config);
@@ -326,14 +329,8 @@ struct Client {
   int fd;
   ev_timer conn_active_watcher;
   ev_timer conn_inactivity_watcher;
-  // This is only active when there is not a bounded number of requests specified
-  ev_timer duration_watcher;
-  ev_timer warmup_watcher;
   std::string selected_proto;
   bool new_connection_requested;
-  // This variable checks whether client's measurements has been added
-  // to the Worker's statistics
-  bool measurement_calculation_done;
   // true if the current connection will be closed, and no more new
   // request cannot be processed.
   bool final;

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -85,6 +85,8 @@ struct Config {
   // rate at which connections should be made
   size_t rate;
   ev_tstamp rate_period;
+  // amount of time to wait before starting measurements
+  ev_tstamp warm_up_time;
   // amount of time to wait for activity on a given connection
   ev_tstamp conn_active_timeout;
   // amount of time to wait after the last request is made on a connection
@@ -306,11 +308,21 @@ struct Client {
   int fd;
   ev_timer conn_active_watcher;
   ev_timer conn_inactivity_watcher;
+  // This is only active when there are theoretically infinite number of requests
+  ev_timer duration_watcher;
+  ev_timer warmup_watcher;
   std::string selected_proto;
   bool new_connection_requested;
   // true if the current connection will be closed, and no more new
   // request cannot be processed.
   bool final;
+  // This variable tells us whether the client is in warmup phase or not or is over
+  // 0 - Not in warm-up phase, this is the initial state in timing experiment
+  // 1 - In warmup phase. This happens after the first connect. 
+  //   - All statistics are skipped/reversed in this phase
+  // 2 - Main duration phase, in timing experiment; Otherwise, the normal phase
+  // 3 - Main duration is over
+  int warmup;
 
   enum { ERR_CONNECT_FAIL = -100 };
 


### PR DESCRIPTION
Arguments are not well checked right now. Need suggestions. So to run our timing test, we need to run:
`./src/h2load -n 0 -c 5 -r 5 --rate-period 10 -t 1 --warm-up-time 5 https://localhost:4500`
This will create 5 clients and have 5 seconds of warm-up time. The main test duration is given as the `rate-period` argument, in this case, which is 10 seconds. Number of connections (`n`) should be `0`. This helps us to know that infinite number of connections are to be tried. Currently, multiple threads are not tried. So, `t` should be `1`.
We also need to check whether previous benchmarks are working fine.